### PR TITLE
wc コマンドを作る

### DIFF
--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -48,9 +48,14 @@ def render_error(argv)
 end
 
 def print_word_count(option, read_file_count, read_file_word, file_size)
-  print read_file_count.to_s.rjust(8) if option['l'] || no_option?(option)
-  print read_file_word.to_s.rjust(8) if option['w'] || no_option?(option)
-  print file_size.to_s.rjust(8) if option['c'] || no_option?(option)
+  if no_option?(option)
+    print read_file_count.to_s.rjust(8)
+    print read_file_word.to_s.rjust(8)
+    print file_size.to_s.rjust(8)
+  end
+  print read_file_count.to_s.rjust(8) if option['l']
+  print read_file_word.to_s.rjust(8) if option['w']
+  print file_size.to_s.rjust(8) if option['c']
 end
 
 def select_file(argv)
@@ -66,7 +71,7 @@ def multiple_argv?(argv)
 end
 
 def no_option?(option)
-  option.all? { |_k, v| v == false }
+  option.all? { |_, v| v == false }
 end
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -69,16 +69,4 @@ def no_option?(option)
   option.all? { |_k, v| v == false }
 end
 
-def calc_max_length(select_file)
-  max = { newlines: 0, words: 0, bytes: 0 }
-  select_file.map do |file_path|
-    read_file = File.read(file_path)
-    file = File.new(file_path)
-    max[:newlines] = read_file.count("\n").length if max[:newlines] < read_file.count("\n").length
-    max[:words] = read_file.split(/\s+/).count.length if max[:words] < read_file.split(/\s+/).count.length
-    max[:bytes] = file.size.length if max[:bytes] < file.size.length
-  end
-  max
-end
-
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -5,78 +5,68 @@
 require 'optparse'
 
 def main
-  @option = ARGV.getopts('lwc')
-  @argv = ARGV
+  option = ARGV.getopts('lwc')
+  argv = ARGV
 
-  if !@argv.empty?
-    print_all_files_word_count
+  if !argv.empty?
+    print_all_files_word_count(option, argv)
   else
-    @stdin = $stdin.read
-    print_stdin_word_count
+    stdin = $stdin.read
+    print_word_count(option, stdin.count("\n"), stdin.split(/\s+/).count, stdin.size)
   end
 end
 
-def print_all_files_word_count
-  render_error
+def print_all_files_word_count(option, argv)
+  render_error(argv)
 
   read_file_count_sum = 0
   read_file_word_sum = 0
   file_size_sum = 0
 
-  select_file.each do |file_path|
+  select_file(argv).each do |file_path|
     read_file = File.read(file_path)
     file = File.new(file_path)
     read_file_count_sum += read_file.count("\n").to_i
     read_file_word_sum += read_file.split(/\s+/).count.to_i
     file_size_sum += file.size.to_i
 
-    print_word_count_each_file(read_file, file, file_path)
+    print_word_count(option, read_file.count("\n"), read_file.split(/\s+/).count, file.size)
+    puts "\s#{file_path}"
   end
 
-  print_total_word_count(read_file_count_sum, read_file_word_sum, file_size_sum) if multiple_argv?
+  return unless multiple_argv?(argv)
+
+  print_word_count(option, read_file_count_sum, read_file_word_sum, file_size_sum)
+  puts "\stotal"
 end
 
-def print_stdin_word_count
-  print @stdin.count("\n").to_s.rjust(8) if @option['l'] || no_option?
-  print @stdin.split(/\s+/).count.to_s.rjust(8) if @option['w'] || no_option?
-  print @stdin.size.to_s.rjust(8) if @option['c'] || no_option?
-end
-
-def render_error
-  @argv.each do |file_path|
+def render_error(argv)
+  argv.each do |file_path|
     puts "ruby wc.rb: #{file_path}: read: Is a directory" if File.directory?(file_path)
     puts "ruby wc.rb: #{file_path}: open: No such file or directory" unless File.exist?(file_path)
   end
 end
 
-def print_word_count_each_file(read_file, file, file_path)
-  print "#{read_file.count("\n").to_s.rjust(8)}\s" if @option['l'] || no_option?
-  print "#{read_file.split(/\s+/).count.to_s.rjust(8)}\s" if @option['w'] || no_option?
-  print "#{file.size.to_s.rjust(8)}\s" if @option['c'] || no_option?
-  puts file_path
+def print_word_count(option, read_file_count, read_file_word, file_size)
+  print read_file_count.to_s.rjust(8) if option['l'] || no_option?(option)
+  print read_file_word.to_s.rjust(8) if option['w'] || no_option?(option)
+  print file_size.to_s.rjust(8) if option['c'] || no_option?(option)
 end
 
-def print_total_word_count(read_file_count_sum, read_file_word_sum, file_size_sum)
-  print "#{read_file_count_sum.to_s.rjust(8)}\s" if @option['l'] || no_option?
-  print "#{read_file_word_sum.to_s.rjust(8)}\s" if @option['w'] || no_option?
-  print "#{file_size_sum.to_s.rjust(8)}\s" if @option['c'] || no_option?
-  puts 'total'
-end
-
-def select_file
-  @argv.select { |file_path| File.file?(file_path) }
+def select_file(argv)
+  argv.select { |file_path| File.file?(file_path) }
 end
 
 def directory?(file_path)
   File.directory?(file_path)
 end
 
-def multiple_argv?
-  @argv.length > 1
+def multiple_argv?(argv)
+  argv.length > 1
 end
 
-def no_option?
-  @option.all? { |_k, v| v == false }
+def no_option?(option)
+  option.all? { |_k, v| v == false }
 end
 
 def calc_max_length(select_file)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -12,7 +12,7 @@ def main
     print_files_word_count(option, argv)
   else
     stdin = $stdin.read
-    print_word_count(option, stdin.count("\n"), stdin.split(/\s+/).count, stdin.size)
+    print_count(option, stdin.count("\n"), stdin.split(/\s+/).count, stdin.size)
   end
 end
 
@@ -25,18 +25,17 @@ def print_files_word_count(option, argv)
 
   select_file(argv).each do |file_path|
     read_file = File.read(file_path)
-    file = File.new(file_path)
     read_file_count_sum += read_file.count("\n").to_i
     read_file_word_sum += read_file.split(/\s+/).count.to_i
-    file_size_sum += file.size.to_i
+    file_size_sum += read_file.size.to_i
 
-    print_word_count(option, read_file.count("\n"), read_file.split(/\s+/).count, file.size)
+    print_count(option, read_file.count("\n"), read_file.split(/\s+/).count, read_file.size)
     puts "\s#{file_path}"
   end
 
-  return unless multiple_argv?(argv)
+  return unless argv.length > 1
 
-  print_word_count(option, read_file_count_sum, read_file_word_sum, file_size_sum)
+  print_count(option, read_file_count_sum, read_file_word_sum, file_size_sum)
   puts "\stotal"
 end
 
@@ -47,27 +46,36 @@ def render_error(argv)
   end
 end
 
-def print_word_count(option, read_file_count, read_file_word, file_size)
+def print_count(option, line_count, word_count, string_count)
   if no_option?(option)
-    print read_file_count.to_s.rjust(8)
-    print read_file_word.to_s.rjust(8)
-    print file_size.to_s.rjust(8)
+    print_all(line_count, word_count, string_count)
+  else
+    print_line_count(line_count) if option['l']
+    print_word_count(word_count) if option['w']
+    print_string_count(string_count) if option['c']
   end
-  print read_file_count.to_s.rjust(8) if option['l']
-  print read_file_word.to_s.rjust(8) if option['w']
-  print file_size.to_s.rjust(8) if option['c']
+end
+
+def print_all(line_count, word_count, string_count)
+  print_line_count(line_count)
+  print_word_count(word_count)
+  print_string_count(string_count)
+end
+
+def print_line_count(line_count)
+  print line_count.to_s.rjust(8)
+end
+
+def print_word_count(word_count)
+  print word_count.to_s.rjust(8)
+end
+
+def print_string_count(string_count)
+  print string_count.to_s.rjust(8)
 end
 
 def select_file(argv)
   argv.select { |file_path| File.file?(file_path) }
-end
-
-def directory?(file_path)
-  File.directory?(file_path)
-end
-
-def multiple_argv?(argv)
-  argv.length > 1
 end
 
 def no_option?(option)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -6,8 +6,17 @@ require 'optparse'
 
 def main
   @option = ARGV.getopts('lwc')
-  @argv = ARGV.empty? ? ['.'] : ARGV
+  @argv = ARGV
 
+  if !@argv.empty?
+    print_all_files_word_count
+  else
+    @stdin = $stdin.read
+    print_stdin_word_count
+  end
+end
+
+def print_all_files_word_count
   render_error
 
   read_file_count_sum = 0
@@ -25,6 +34,12 @@ def main
   end
 
   print_total_word_count(read_file_count_sum, read_file_word_sum, file_size_sum) if multiple_argv?
+end
+
+def print_stdin_word_count
+  print @stdin.count("\n").to_s.rjust(8) if @option['l'] || no_option?
+  print @stdin.split(/\s+/).count.to_s.rjust(8) if @option['w'] || no_option?
+  print @stdin.size.to_s.rjust(8) if @option['c'] || no_option?
 end
 
 def render_error
@@ -75,13 +90,5 @@ def calc_max_length(select_file)
   end
   max
 end
-
-# TODO:
-# ディレクトリを引数にとる
-# ❯ wc ~/Desktop/ruby-practices/05.wc
-# wc: /Users/koyama/Desktop/ruby-practices/05.wc: read: Is a directory
-
-# ファイルだと
-# wc: /Users/koyama/Desktop/ruby-practices/05.wc/wrb: open: No such file or directory
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -2,7 +2,10 @@
 
 # frozen_string_literal: true
 
+require 'optparse'
+
 def main
+  @option = ARGV.getopts('lwc')
   @argv = ARGV.empty? ? ['.'] : ARGV
 
   render_error
@@ -18,55 +21,67 @@ def main
     read_file_word_sum += read_file.split(/\s+/).count.to_i
     file_size_sum += file.size.to_i
 
-    print_hoge(read_file, file, file_path)
+    print_word_count_each_file(read_file, file, file_path)
   end
 
-  print_total(read_file_count_sum, read_file_word_sum, file_size_sum) if multiple_argv?
+  print_total_word_count(read_file_count_sum, read_file_word_sum, file_size_sum) if multiple_argv?
 end
 
 def render_error
   @argv.each do |file_path|
-    return puts "ruby wc.rb: #{file_path}: read: Is a directory" unless File.exist?(file_path)
+    puts "ruby wc.rb: #{file_path}: read: Is a directory" if File.directory?(file_path)
+    puts "ruby wc.rb: #{file_path}: open: No such file or directory" unless File.exist?(file_path)
   end
 end
 
-def print_hoge(read_file, file, file_path)
-  puts read_file.count("\n")
-  # puts read_file.lines.count
-  puts read_file.split(/\s+/).count
-  puts file.size
+def print_word_count_each_file(read_file, file, file_path)
+  print "#{read_file.count("\n").to_s.rjust(8)}\s" if @option['l'] || no_option?
+  print "#{read_file.split(/\s+/).count.to_s.rjust(8)}\s" if @option['w'] || no_option?
+  print "#{file.size.to_s.rjust(8)}\s" if @option['c'] || no_option?
   puts file_path
 end
 
-def print_total(read_file_count_sum, read_file_word_sum, file_size_sum)
+def print_total_word_count(read_file_count_sum, read_file_word_sum, file_size_sum)
+  print "#{read_file_count_sum.to_s.rjust(8)}\s" if @option['l'] || no_option?
+  print "#{read_file_word_sum.to_s.rjust(8)}\s" if @option['w'] || no_option?
+  print "#{file_size_sum.to_s.rjust(8)}\s" if @option['c'] || no_option?
   puts 'total'
-  puts read_file_count_sum
-  puts read_file_word_sum
-  puts file_size_sum
 end
 
 def select_file
   @argv.select { |file_path| File.file?(file_path) }
 end
 
-def directory?
-  @argv.select { |file_path| File.directory?(file_path) }
+def directory?(file_path)
+  File.directory?(file_path)
 end
 
 def multiple_argv?
   @argv.length > 1
 end
 
-# TODO:
-# 複数のファイルを指定すると合計が表示される
+def no_option?
+  @option.all? { |_k, v| v == false }
+end
 
+def calc_max_length(select_file)
+  max = { newlines: 0, words: 0, bytes: 0 }
+  select_file.map do |file_path|
+    read_file = File.read(file_path)
+    file = File.new(file_path)
+    max[:newlines] = read_file.count("\n").length if max[:newlines] < read_file.count("\n").length
+    max[:words] = read_file.split(/\s+/).count.length if max[:words] < read_file.split(/\s+/).count.length
+    max[:bytes] = file.size.length if max[:bytes] < file.size.length
+  end
+  max
+end
+
+# TODO:
 # ディレクトリを引数にとる
 # ❯ wc ~/Desktop/ruby-practices/05.wc
 # wc: /Users/koyama/Desktop/ruby-practices/05.wc: read: Is a directory
 
 # ファイルだと
 # wc: /Users/koyama/Desktop/ruby-practices/05.wc/wrb: open: No such file or directory
-
-# 引数がない時は何かを待っている？
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -1,20 +1,48 @@
 #! usr/bin/env ruby
 
+# frozen_string_literal: true
+
 def main
   @argv = ARGV.empty? ? ['.'] : ARGV
-  @argv.each do |file_path|
-    return puts "ruby wc.rb: #{file_path}: read: Is a directory"
-    select_file.each do |file_path|
-      read_file = File.read(file_path)
-      file = File.new(file_path)
-      puts read_file.count("\n")
-      # puts read_file.lines.count
-      puts read_file.split(/\s+/).count
-      puts file.size
-      puts file_path
-      puts "total" if multiple_argv?
-    end
+
+  render_error
+
+  read_file_count_sum = 0
+  read_file_word_sum = 0
+  file_size_sum = 0
+
+  select_file.each do |file_path|
+    read_file = File.read(file_path)
+    file = File.new(file_path)
+    read_file_count_sum += read_file.count("\n").to_i
+    read_file_word_sum += read_file.split(/\s+/).count.to_i
+    file_size_sum += file.size.to_i
+
+    print_hoge(read_file, file, file_path)
   end
+
+  print_total(read_file_count_sum, read_file_word_sum, file_size_sum) if multiple_argv?
+end
+
+def render_error
+  @argv.each do |file_path|
+    return puts "ruby wc.rb: #{file_path}: read: Is a directory" unless File.exist?(file_path)
+  end
+end
+
+def print_hoge(read_file, file, file_path)
+  puts read_file.count("\n")
+  # puts read_file.lines.count
+  puts read_file.split(/\s+/).count
+  puts file.size
+  puts file_path
+end
+
+def print_total(read_file_count_sum, read_file_word_sum, file_size_sum)
+  puts 'total'
+  puts read_file_count_sum
+  puts read_file_word_sum
+  puts file_size_sum
 end
 
 def select_file
@@ -31,11 +59,13 @@ end
 
 # TODO:
 # 複数のファイルを指定すると合計が表示される
-# ワイルドカード
 
 # ディレクトリを引数にとる
 # ❯ wc ~/Desktop/ruby-practices/05.wc
 # wc: /Users/koyama/Desktop/ruby-practices/05.wc: read: Is a directory
+
+# ファイルだと
+# wc: /Users/koyama/Desktop/ruby-practices/05.wc/wrb: open: No such file or directory
 
 # 引数がない時は何かを待っている？
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -9,14 +9,14 @@ def main
   argv = ARGV
 
   if !argv.empty?
-    print_all_files_word_count(option, argv)
+    print_files_word_count(option, argv)
   else
     stdin = $stdin.read
     print_word_count(option, stdin.count("\n"), stdin.split(/\s+/).count, stdin.size)
   end
 end
 
-def print_all_files_word_count(option, argv)
+def print_files_word_count(option, argv)
   render_error(argv)
 
   read_file_count_sum = 0

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -1,0 +1,42 @@
+#! usr/bin/env ruby
+
+def main
+  @argv = ARGV.empty? ? ['.'] : ARGV
+  @argv.each do |file_path|
+    return puts "ruby wc.rb: #{file_path}: read: Is a directory"
+    select_file.each do |file_path|
+      read_file = File.read(file_path)
+      file = File.new(file_path)
+      puts read_file.count("\n")
+      # puts read_file.lines.count
+      puts read_file.split(/\s+/).count
+      puts file.size
+      puts file_path
+      puts "total" if multiple_argv?
+    end
+  end
+end
+
+def select_file
+  @argv.select { |file_path| File.file?(file_path) }
+end
+
+def directory?
+  @argv.select { |file_path| File.directory?(file_path) }
+end
+
+def multiple_argv?
+  @argv.length > 1
+end
+
+# TODO:
+# 複数のファイルを指定すると合計が表示される
+# ワイルドカード
+
+# ディレクトリを引数にとる
+# ❯ wc ~/Desktop/ruby-practices/05.wc
+# wc: /Users/koyama/Desktop/ruby-practices/05.wc: read: Is a directory
+
+# 引数がない時は何かを待っている？
+
+main


### PR DESCRIPTION
## wc コマンド（本物と作成したものとの比較）
- 標準入力した結果
<img width="497" alt="スクリーンショット 2023-03-09 21 12 14" src="https://user-images.githubusercontent.com/50766994/224019693-7bd875af-abd0-427e-a78c-b1412f06a3ad.png">

- 引数に1つのファイル名
<img width="499" alt="スクリーンショット 2023-03-09 21 12 54" src="https://user-images.githubusercontent.com/50766994/224019837-5f5a824d-fb01-4a2a-a88f-418a55ddfc4a.png">

- 引数に複数のファイル名
<img width="496" alt="スクリーンショット 2023-03-09 21 13 54" src="https://user-images.githubusercontent.com/50766994/224020052-e6ea0042-775e-4dfd-9520-f357dbb786f4.png">

- `l` `w` `c` の各オプション
<img width="498" alt="スクリーンショット 2023-03-09 21 14 45" src="https://user-images.githubusercontent.com/50766994/224020228-e44e01ea-1d9e-4ace-bc95-7aa548ec6a7c.png">

- オプションを2つと3つつける
<img width="496" alt="スクリーンショット 2023-03-09 21 16 34" src="https://user-images.githubusercontent.com/50766994/224020578-28476343-4a23-401f-8a57-d4d6d379d167.png">

- パイプを使って標準入力を受け取る
<img width="499" alt="スクリーンショット 2023-03-09 21 18 26" src="https://user-images.githubusercontent.com/50766994/224020931-f8b97002-bb52-4caf-845b-6a8666a8bc3a.png">

自作のlsコマンドでは、ファイル名の最後に余白（`\s\s`）を入れているため出力結果が異なっています。
```
# 列ごとの幅を揃える
def adjust_width(file_array)
  file_array.each_with_object([]) do |array, new_array|
    max_num = array.map(&:length).max
    new_array << array.map { |file| "#{file.ljust(max_num)}\s\s" }
  end
end
```
「wc.rb」という文字列をターミナルから打ち込むと値は一緒になります
<img width="498" alt="スクリーンショット 2023-03-09 21 32 04" src="https://user-images.githubusercontent.com/50766994/224024043-cdad27d2-d5d7-40eb-ba4c-ed88394e7ab2.png">

## rubocopが通っていること
<img width="499" alt="スクリーンショット 2023-03-09 21 32 42" src="https://user-images.githubusercontent.com/50766994/224024215-39bbe7ed-310f-40a9-bf54-c1b88bea6b4f.png">
